### PR TITLE
Update replica set configuration for driver 2.0

### DIFF
--- a/mongo-store.js
+++ b/mongo-store.js
@@ -146,7 +146,7 @@ module.exports = function(opts) {
 	var servconf = conf.replicaset.servers[i]
 	rservs.push(new mongo.Server(servconf.host,servconf.port,dbopts))
       }
-      var rset = new mongo.ReplSetServers(rservs)
+      var rset = new mongo.ReplSet(rservs)
       dbinst = new mongo.Db( conf.name, rset, dbopts )
     }
     else {


### PR DESCRIPTION
When the version changed for node-mongodb-native (1.4.30 -> 2.0.43),
there was a name change from ReplSetServer to ReplSet.